### PR TITLE
Geordi Deployment

### DIFF
--- a/tasks/setup_virtualenv.yml
+++ b/tasks/setup_virtualenv.yml
@@ -44,7 +44,7 @@
   tags: django
 
 - name: run pip with default response of "(w)wipe" for required repos
-  shell: yes w | {{app_env_dir}}/bin/pip install -r {{requirements_txt_path}}
+  shell: yes w | {{app_env_dir}}/bin/pip install -r {{requirements_txt_path}} --process-dependency-links
   sudo: yes
   sudo_user: "{{app_user}}"
   tags: django


### PR DESCRIPTION
Added option '--process-dependency-links' to pip installation command
to allow package 'geordi' to successfully install.

This option will be deprecated in future versions of pip, so we will
need to remove it if/when we upgrade.

This may also be rendered moot if the owner of geordi updates the
setup file to indicate a newer version of gprof2dot.